### PR TITLE
Create settings screen for app customization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ android {
 
 dependencies {
     implementation(libs.geckoview)
+    implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/assets/extensions/youtoob_player/manifest.json
+++ b/app/src/main/assets/extensions/youtoob_player/manifest.json
@@ -24,6 +24,17 @@
       ],
       "run_at": "document_end",
       "all_frames": false
+    },
+    {
+      "js": [
+        "scripts/settings_injector.js"
+      ],
+      "matches": [
+        "*://*.youtube.com/*",
+        "*://m.youtube.com/*"
+      ],
+      "run_at": "document_end",
+      "all_frames": false
     }
   ],
   "web_accessible_resources": [

--- a/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
@@ -12,24 +12,28 @@
     const INJECTION_DELAY_MS = 500;
 
     function isSettingsPage() {
-        return location.pathname.includes('/account');
+        return location.pathname.includes('/account') ||
+               location.pathname.includes('/select_site');
     }
 
     function findSettingsContainer() {
-        // YouTube mobile settings page structure
-        // Look for the settings menu container
-        const containers = document.querySelectorAll('ytm-section-list-renderer, ytm-settings-renderer, .settings-list');
-        for (const container of containers) {
-            if (container.querySelector('ytm-compact-link-renderer, ytm-settings-item-renderer, .menu-item')) {
-                return container;
-            }
+        // Try various YouTube mobile settings containers
+        const selectors = [
+            'ytm-section-list-renderer',
+            'ytm-settings-renderer',
+            '.settings-list',
+            'ytm-browse',
+            'ytm-single-column-browse-results-renderer',
+            '#contents',
+            'ytm-app [role="main"]',
+            'ytm-app'
+        ];
+
+        for (const selector of selectors) {
+            const el = document.querySelector(selector);
+            if (el) return el;
         }
-        // Fallback: look for any list of settings-like items
-        const settingsList = document.querySelector('[role="list"], .list-container');
-        if (settingsList && settingsList.querySelector('a, button')) {
-            return settingsList;
-        }
-        return null;
+        return document.body;
     }
 
     function createSettingsItem() {
@@ -52,8 +56,11 @@
             <span style="font-size: 14px; color: inherit;">YouToob Settings</span>
         `;
 
-        item.addEventListener('click', () => {
-            window.location.href = 'youtoob://settings';
+        item.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            // Use replace() to avoid adding to history (prevents re-triggering on back/forward)
+            window.location.replace('youtoob://settings');
         });
 
         item.addEventListener('touchstart', () => {

--- a/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
@@ -89,6 +89,10 @@
         // Insert at the top of the container
         if (container.firstChild) {
             container.insertBefore(item, container.firstChild);
+            // Remove border-top from the next sibling (Switch account) to avoid double divider
+            if (item.nextElementSibling) {
+                item.nextElementSibling.style.borderTop = 'none';
+            }
         } else {
             container.appendChild(item);
         }

--- a/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
@@ -17,43 +17,52 @@
     }
 
     function findSettingsContainer() {
-        // Try various YouTube mobile settings containers
+        // Target the ytm-settings container specifically
+        const ytmSettings = document.querySelector('ytm-settings.cairo-settings');
+        if (ytmSettings) return ytmSettings;
+
+        // Fallback selectors
         const selectors = [
+            'ytm-settings',
             'ytm-section-list-renderer',
-            'ytm-settings-renderer',
-            '.settings-list',
-            'ytm-browse',
-            'ytm-single-column-browse-results-renderer',
-            '#contents',
-            'ytm-app [role="main"]',
-            'ytm-app'
+            'ytm-settings-renderer'
         ];
 
         for (const selector of selectors) {
             const el = document.querySelector(selector);
             if (el) return el;
         }
-        return document.body;
+        return null;
     }
 
     function createSettingsItem() {
+        // Match YouTube's native settings item structure
         const item = document.createElement('div');
         item.id = SETTINGS_ID;
-        item.style.cssText = `
-            padding: 16px 24px;
-            display: flex;
-            align-items: center;
-            cursor: pointer;
-            background: transparent;
-            border-bottom: 1px solid rgba(255,255,255,0.1);
-        `;
+        item.className = 'setting-generic-category cairo-settings';
+        item.setAttribute('role', 'button');
+        item.setAttribute('tabindex', '0');
 
+        // Use YouTube's gear icon SVG (same as General settings)
         item.innerHTML = `
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 24px; opacity: 0.9;">
-                <circle cx="12" cy="12" r="3"></circle>
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-            </svg>
-            <span style="font-size: 14px; color: inherit;">YouToob Settings</span>
+            <div class="setting-generic-category-block">
+                <div class="setting-generic-category-icon">
+                    <c3-icon fill-icon="false">
+                        <span class="yt-icon-shape ytSpecIconShapeHost">
+                            <div style="width: 100%; height: 100%; display: block; fill: currentcolor;">
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" focusable="false" aria-hidden="true" style="pointer-events: none; display: inherit; width: 100%; height: 100%;">
+                                    <path d="M12.844 1h-1.687a2 2 0 00-1.962 1.616 3 3 0 01-3.92 2.263 2 2 0 00-2.38.891l-.842 1.46a2 2 0 00.417 2.507 3 3 0 010 4.525 2 2 0 00-.417 2.507l.843 1.46a2 2 0 002.38.892 3.001 3.001 0 013.918 2.263A2 2 0 0011.157 23h1.686a2 2 0 001.963-1.615 3.002 3.002 0 013.92-2.263 2 2 0 002.38-.892l.842-1.46a2 2 0 00-.418-2.507 3 3 0 010-4.526 2 2 0 00.418-2.508l-.843-1.46a2 2 0 00-2.38-.891 3 3 0 01-3.919-2.263A2 2 0 0012.844 1Zm-1.767 2.347a6 6 0 00.08-.347h1.687a4.98 4.98 0 002.407 3.37 4.98 4.98 0 004.122.4l.843 1.46A4.98 4.98 0 0018.5 12a4.98 4.98 0 001.716 3.77l-.843 1.46a4.98 4.98 0 00-4.123.4A4.979 4.979 0 0012.843 21h-1.686a4.98 4.98 0 00-2.408-3.371 4.999 4.999 0 00-4.12-.399l-.844-1.46A4.979 4.979 0 005.5 12a4.98 4.98 0 00-1.715-3.77l.842-1.459a4.98 4.98 0 004.123-.399 4.981 4.981 0 002.327-3.025ZM16 12a4 4 0 11-7.999 0 4 4 0 018 0Zm-4 2a2 2 0 100-4 2 2 0 000 4Z"></path>
+                                </svg>
+                            </div>
+                        </span>
+                    </c3-icon>
+                </div>
+                <div class="setting-generic-category-title-block cairo-settings">
+                    <div class="title-text">
+                        <span class="yt-core-attributed-string" role="text">YouToob Settings</span>
+                    </div>
+                </div>
+            </div>
         `;
 
         item.addEventListener('click', (e) => {
@@ -61,14 +70,6 @@
             e.stopPropagation();
             // Use replace() to avoid adding to history (prevents re-triggering on back/forward)
             window.location.replace('youtoob://settings');
-        });
-
-        item.addEventListener('touchstart', () => {
-            item.style.background = 'rgba(255,255,255,0.1)';
-        });
-
-        item.addEventListener('touchend', () => {
-            item.style.background = 'transparent';
         });
 
         return item;

--- a/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/settings_injector.js
@@ -1,0 +1,118 @@
+// Settings menu injection for YouToob
+// Injects "YouToob Settings" into YouTube's settings page
+
+(function() {
+    'use strict';
+
+    // Guard against multiple runs
+    if (window._youtoobSettingsInjectorLoaded) return;
+    window._youtoobSettingsInjectorLoaded = true;
+
+    const SETTINGS_ID = 'youtoob-settings-item';
+    const INJECTION_DELAY_MS = 500;
+
+    function isSettingsPage() {
+        return location.pathname.includes('/account');
+    }
+
+    function findSettingsContainer() {
+        // YouTube mobile settings page structure
+        // Look for the settings menu container
+        const containers = document.querySelectorAll('ytm-section-list-renderer, ytm-settings-renderer, .settings-list');
+        for (const container of containers) {
+            if (container.querySelector('ytm-compact-link-renderer, ytm-settings-item-renderer, .menu-item')) {
+                return container;
+            }
+        }
+        // Fallback: look for any list of settings-like items
+        const settingsList = document.querySelector('[role="list"], .list-container');
+        if (settingsList && settingsList.querySelector('a, button')) {
+            return settingsList;
+        }
+        return null;
+    }
+
+    function createSettingsItem() {
+        const item = document.createElement('div');
+        item.id = SETTINGS_ID;
+        item.style.cssText = `
+            padding: 16px 24px;
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            background: transparent;
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+        `;
+
+        item.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 24px; opacity: 0.9;">
+                <circle cx="12" cy="12" r="3"></circle>
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+            </svg>
+            <span style="font-size: 14px; color: inherit;">YouToob Settings</span>
+        `;
+
+        item.addEventListener('click', () => {
+            window.location.href = 'youtoob://settings';
+        });
+
+        item.addEventListener('touchstart', () => {
+            item.style.background = 'rgba(255,255,255,0.1)';
+        });
+
+        item.addEventListener('touchend', () => {
+            item.style.background = 'transparent';
+        });
+
+        return item;
+    }
+
+    function injectSettingsItem() {
+        // Don't inject if already present
+        if (document.getElementById(SETTINGS_ID)) return;
+
+        if (!isSettingsPage()) return;
+
+        const container = findSettingsContainer();
+        if (!container) return;
+
+        const item = createSettingsItem();
+
+        // Insert at the top of the container
+        if (container.firstChild) {
+            container.insertBefore(item, container.firstChild);
+        } else {
+            container.appendChild(item);
+        }
+    }
+
+    // Inject on load
+    function init() {
+        if (!isSettingsPage()) return;
+        setTimeout(injectSettingsItem, INJECTION_DELAY_MS);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    // Re-inject on SPA navigation
+    let lastUrl = location.href;
+    const observer = new MutationObserver(() => {
+        if (location.href !== lastUrl) {
+            lastUrl = location.href;
+            // Remove old item if navigating away
+            const oldItem = document.getElementById(SETTINGS_ID);
+            if (oldItem) oldItem.remove();
+            // Reset the guard so we can inject again
+            setTimeout(injectSettingsItem, INJECTION_DELAY_MS);
+        } else if (isSettingsPage()) {
+            // Page content might have changed, try to inject
+            setTimeout(injectSettingsItem, INJECTION_DELAY_MS);
+        }
+    });
+
+    observer.observe(document.body, { subtree: true, childList: true });
+})();

--- a/app/src/main/assets/extensions/youtoob_player/scripts/src/02-constants.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/src/02-constants.js
@@ -27,6 +27,7 @@ const FALLBACK_QUALITIES = ['hd1080', 'hd720', 'large', 'medium', 'small'];
 const QUALITY_PRIORITY = ['hd2160', 'hd1440', 'hd1080', 'hd720', 'large', 'medium', 'small', 'tiny'];
 const AUTO_QUALITY_POLL_INTERVAL_MS = 100;
 const AUTO_QUALITY_MAX_ATTEMPTS = 50;
+const DEFAULT_SPEED = 1.0;
 
 // Polling and delay constants
 const NAV_BUTTON_POLL_INTERVAL_MS = 2000;

--- a/app/src/main/assets/extensions/youtoob_player/scripts/src/13-main.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/src/13-main.js
@@ -80,8 +80,9 @@ function createCustomControls(video) {
     setupTopBar(video, controls);
     setupGestures(video, overlay);
 
-    // Auto-set to highest available quality
+    // Apply user's default quality and speed settings
     autoSetQuality();
+    autoSetSpeed(video);
 
     // Menu toggle buttons
     elements.speedBtn.addEventListener('click', (e) => {

--- a/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.wpinrui.youtoob.ui.DownloadsActivity
 import com.wpinrui.youtoob.ui.GeckoViewScreen
-import com.wpinrui.youtoob.ui.SettingsActivity
 import com.wpinrui.youtoob.ui.components.YoutoobBottomNav
 import com.wpinrui.youtoob.ui.navigation.NavDestination
 import com.wpinrui.youtoob.ui.theme.YouToobTheme
@@ -58,9 +57,6 @@ class MainActivity : ComponentActivity() {
                                     }
                                     destination == NavDestination.DOWNLOADS -> {
                                         startActivity(Intent(this@MainActivity, DownloadsActivity::class.java))
-                                    }
-                                    destination == NavDestination.SETTINGS -> {
-                                        startActivity(Intent(this@MainActivity, SettingsActivity::class.java))
                                     }
                                 }
                             },

--- a/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
@@ -8,7 +8,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "youtoob_settings")
@@ -66,8 +65,6 @@ class SettingsRepository(private val context: Context) {
             autoplayEnabled = preferences[PreferenceKeys.AUTOPLAY_ENABLED] ?: true
         )
     }
-
-    suspend fun getSettingsSnapshot(): YoutoobSettings = settings.first()
 
     suspend fun setDefaultQuality(quality: VideoQuality) {
         context.dataStore.edit { preferences ->

--- a/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
@@ -1,0 +1,89 @@
+package com.wpinrui.youtoob.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "youtoob_settings")
+
+enum class VideoQuality(val label: String, val value: String) {
+    AUTO("Auto", "auto"),
+    P480("480p", "480"),
+    P720("720p", "720"),
+    P1080("1080p", "1080"),
+    P1440("1440p", "1440"),
+    P4K("4K", "2160");
+
+    companion object {
+        fun fromValue(value: String): VideoQuality =
+            entries.find { it.value == value } ?: AUTO
+    }
+}
+
+enum class PlaybackSpeed(val label: String, val value: Float) {
+    X0_5("0.5x", 0.5f),
+    X0_75("0.75x", 0.75f),
+    X1("1x", 1.0f),
+    X1_25("1.25x", 1.25f),
+    X1_5("1.5x", 1.5f),
+    X2("2x", 2.0f);
+
+    companion object {
+        fun fromValue(value: Float): PlaybackSpeed =
+            entries.find { it.value == value } ?: X1
+    }
+}
+
+data class YoutoobSettings(
+    val defaultQuality: VideoQuality = VideoQuality.AUTO,
+    val defaultSpeed: PlaybackSpeed = PlaybackSpeed.X1,
+    val autoplayEnabled: Boolean = true
+)
+
+class SettingsRepository(private val context: Context) {
+
+    private object PreferenceKeys {
+        val DEFAULT_QUALITY = stringPreferencesKey("default_quality")
+        val DEFAULT_SPEED = stringPreferencesKey("default_speed")
+        val AUTOPLAY_ENABLED = booleanPreferencesKey("autoplay_enabled")
+    }
+
+    val settings: Flow<YoutoobSettings> = context.dataStore.data.map { preferences ->
+        YoutoobSettings(
+            defaultQuality = VideoQuality.fromValue(
+                preferences[PreferenceKeys.DEFAULT_QUALITY] ?: VideoQuality.AUTO.value
+            ),
+            defaultSpeed = PlaybackSpeed.fromValue(
+                preferences[PreferenceKeys.DEFAULT_SPEED]?.toFloatOrNull() ?: PlaybackSpeed.X1.value
+            ),
+            autoplayEnabled = preferences[PreferenceKeys.AUTOPLAY_ENABLED] ?: true
+        )
+    }
+
+    suspend fun getSettingsSnapshot(): YoutoobSettings = settings.first()
+
+    suspend fun setDefaultQuality(quality: VideoQuality) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferenceKeys.DEFAULT_QUALITY] = quality.value
+        }
+    }
+
+    suspend fun setDefaultSpeed(speed: PlaybackSpeed) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferenceKeys.DEFAULT_SPEED] = speed.value.toString()
+        }
+    }
+
+    suspend fun setAutoplayEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferenceKeys.AUTOPLAY_ENABLED] = enabled
+        }
+    }
+}

--- a/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
@@ -10,6 +10,7 @@ data class ShareRequest(val title: String?, val text: String?, val uri: String?)
 
 private const val YOUTOOB_SCHEME = "youtoob"
 private const val GOBACK_ACTION = "goback"
+private const val SETTINGS_ACTION = "settings"
 
 class GeckoSessionDelegate(
     private val onFullscreenChange: (Boolean) -> Unit,
@@ -19,7 +20,8 @@ class GeckoSessionDelegate(
     private val onPageLoaded: (GeckoSession) -> Unit = {},
     private val onUrlChange: (String, GeckoSession) -> Unit = { _, _ -> },
     private val onShareRequest: (ShareRequest, (Boolean) -> Unit) -> Unit = { _, callback -> callback(false) },
-    private val onGoBackRequest: (GeckoSession) -> Unit = {}
+    private val onGoBackRequest: (GeckoSession) -> Unit = {},
+    private val onSettingsRequest: () -> Unit = {}
 ) : GeckoSession.ContentDelegate,
     GeckoSession.PermissionDelegate,
     GeckoSession.ProgressDelegate,
@@ -118,6 +120,7 @@ class GeckoSessionDelegate(
             val action = uri.removePrefix("$YOUTOOB_SCHEME://")
             when (action) {
                 GOBACK_ACTION -> onGoBackRequest(session)
+                SETTINGS_ACTION -> onSettingsRequest()
             }
             // Block the navigation - we handled it
             return GeckoResult.fromValue(AllowOrDeny.DENY)

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -142,7 +142,6 @@ fun GeckoViewScreen(
 ) {
     val context = LocalContext.current
     val activity = context as? Activity
-    var isFullscreen by remember { mutableStateOf(false) }
     var currentUrl by remember { mutableStateOf("") }
 
     val audioManager = remember { context.getSystemService<AudioManager>() }
@@ -188,7 +187,6 @@ fun GeckoViewScreen(
     val delegate = remember {
         GeckoSessionDelegate(
             onFullscreenChange = { fullscreen ->
-                isFullscreen = fullscreen
                 onFullscreenChange(fullscreen)
                 activity?.let {
                     setFullscreen(it, fullscreen)

--- a/app/src/main/java/com/wpinrui/youtoob/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/SettingsActivity.kt
@@ -4,21 +4,43 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.wpinrui.youtoob.data.PlaybackSpeed
+import com.wpinrui.youtoob.data.SettingsRepository
+import com.wpinrui.youtoob.data.VideoQuality
+import com.wpinrui.youtoob.data.YoutoobSettings
 import com.wpinrui.youtoob.ui.theme.YouToobTheme
+import kotlinx.coroutines.launch
 
 class SettingsActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -27,10 +49,15 @@ class SettingsActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             YouToobTheme {
+                val context = LocalContext.current
+                val repository = remember { SettingsRepository(context) }
+                val settings by repository.settings.collectAsState(initial = YoutoobSettings())
+                val scope = rememberCoroutineScope()
+
                 Scaffold(
                     topBar = {
                         TopAppBar(
-                            title = { Text("Settings") },
+                            title = { Text("YouToob Settings") },
                             navigationIcon = {
                                 IconButton(onClick = { finish() }) {
                                     Icon(
@@ -43,19 +70,133 @@ class SettingsActivity : ComponentActivity() {
                     },
                     modifier = Modifier.fillMaxSize()
                 ) { innerPadding ->
-                    Box(
+                    Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(innerPadding),
-                        contentAlignment = Alignment.Center
+                            .padding(innerPadding)
+                            .padding(16.dp)
                     ) {
-                        Text(
-                            text = "Settings coming soon",
-                            style = MaterialTheme.typography.bodyLarge
+                        SettingsHeader("Playback")
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        DropdownSetting(
+                            title = "Default quality",
+                            subtitle = settings.defaultQuality.label,
+                            options = VideoQuality.entries.map { it.label },
+                            selectedIndex = VideoQuality.entries.indexOf(settings.defaultQuality),
+                            onSelect = { index ->
+                                scope.launch {
+                                    repository.setDefaultQuality(VideoQuality.entries[index])
+                                }
+                            }
+                        )
+
+                        DropdownSetting(
+                            title = "Default speed",
+                            subtitle = settings.defaultSpeed.label,
+                            options = PlaybackSpeed.entries.map { it.label },
+                            selectedIndex = PlaybackSpeed.entries.indexOf(settings.defaultSpeed),
+                            onSelect = { index ->
+                                scope.launch {
+                                    repository.setDefaultSpeed(PlaybackSpeed.entries[index])
+                                }
+                            }
+                        )
+
+                        ToggleSetting(
+                            title = "Autoplay",
+                            subtitle = if (settings.autoplayEnabled) "Enabled" else "Disabled",
+                            checked = settings.autoplayEnabled,
+                            onCheckedChange = { enabled ->
+                                scope.launch {
+                                    repository.setAutoplayEnabled(enabled)
+                                }
+                            }
                         )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SettingsHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(vertical = 8.dp)
+    )
+}
+
+@Composable
+private fun DropdownSetting(
+    title: String,
+    subtitle: String,
+    options: List<String>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = true }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEachIndexed { index, option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onSelect(index)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToggleSetting(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange
+        )
     }
 }

--- a/app/src/main/java/com/wpinrui/youtoob/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/SettingsActivity.kt
@@ -48,7 +48,7 @@ class SettingsActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            YouToobTheme {
+            YouToobTheme(darkTheme = true, dynamicColor = false) {
                 val context = LocalContext.current
                 val repository = remember { SettingsRepository(context) }
                 val settings by repository.settings.collectAsState(initial = YoutoobSettings())

--- a/app/src/main/java/com/wpinrui/youtoob/ui/navigation/NavDestination.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/navigation/NavDestination.kt
@@ -3,11 +3,11 @@ package com.wpinrui.youtoob.ui.navigation
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Subscriptions
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Home
-import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Subscriptions
 import androidx.compose.ui.graphics.vector.ImageVector
 
@@ -34,10 +34,11 @@ enum class NavDestination(
         Icons.Outlined.Download,
         "Downloads"
     ),
-    SETTINGS(
-        Icons.Filled.Settings,
-        Icons.Outlined.Settings,
-        "Settings"
+    YOU(
+        Icons.Filled.Person,
+        Icons.Outlined.Person,
+        "You",
+        "https://m.youtube.com/feed/you"
     );
 
     val isYouTubeDestination: Boolean

--- a/app/src/main/java/com/wpinrui/youtoob/ui/navigation/NavDestination.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/navigation/NavDestination.kt
@@ -38,7 +38,7 @@ enum class NavDestination(
         Icons.Filled.Person,
         Icons.Outlined.Person,
         "You",
-        "https://m.youtube.com/feed/you"
+        "https://m.youtube.com/feed/library"
     );
 
     val isYouTubeDestination: Boolean

--- a/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
@@ -8,12 +8,18 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+
+private val PureBlack = Color(0xFF000000)
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
     secondary = PurpleGrey80,
-    tertiary = Pink80
+    tertiary = Pink80,
+    background = PureBlack,
+    surface = PureBlack,
+    surfaceVariant = Color(0xFF1A1A1A)
 )
 
 private val LightColorScheme = lightColorScheme(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 geckoview = "133.0.20241209150345"
+datastore = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +28,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 geckoview = { group = "org.mozilla.geckoview", name = "geckoview", version.ref = "geckoview" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Add "You" tab to bottom navigation that navigates to YouTube's profile page
- Inject "YouToob Settings" item into YouTube's settings menu via JS extension
- Create SettingsActivity with quality, speed, and autoplay controls
- Persist settings using DataStore
- Apply user settings to video playback (quality and speed)

## Changes
- Added DataStore dependency for settings persistence
- Replaced Settings tab with You tab (m.youtube.com/feed/you)
- Created SettingsRepository with VideoQuality, PlaybackSpeed enums
- Implemented SettingsActivity with dropdown and toggle controls
- Added youtoob://settings URL scheme handler
- Created settings_injector.js to inject settings menu item
- Modified player.js to read and apply user settings

## Test plan
- [ ] "You" tab navigates to YouTube profile
- [ ] "YouToob Settings" appears in YouTube's settings page
- [ ] Tapping settings item opens native settings screen
- [ ] Quality dropdown changes and persists
- [ ] Speed dropdown changes and persists
- [ ] Autoplay toggle changes and persists
- [ ] Settings apply to new video playback

Closes #18