### PR TITLE
Upgrade GeckoView 133 to 145 for DevTools compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ app/src/main/assets/extensions/youtoob_player/scripts/player.js
 # Android/Gradle
 *.iml
 .gradle
+.kotlin
 /local.properties
 local.properties
 /build

--- a/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoRuntimeProvider.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoRuntimeProvider.kt
@@ -39,25 +39,21 @@ object GeckoRuntimeProvider {
 
     private fun setupPromptDelegate(runtime: GeckoRuntime) {
         runtime.webExtensionController.promptDelegate = object : WebExtensionController.PromptDelegate {
-            override fun onInstallPrompt(extension: WebExtension): GeckoResult<AllowOrDeny>? {
-                Log.i(TAG, "Auto-allowing extension install: ${extension.metaData?.name}")
-                return GeckoResult.fromValue(AllowOrDeny.ALLOW)
-            }
-
             override fun onUpdatePrompt(
-                current: WebExtension,
-                updated: WebExtension,
-                newPermissions: Array<out String>,
-                newOrigins: Array<out String>
+                extension: WebExtension,
+                permissions: Array<out String>,
+                origins: Array<out String>,
+                newPermissions: Array<out String>
             ): GeckoResult<AllowOrDeny>? {
-                Log.i(TAG, "Auto-allowing extension update: ${updated.metaData?.name}")
+                Log.i(TAG, "Auto-allowing extension update: ${extension.metaData?.name}")
                 return GeckoResult.fromValue(AllowOrDeny.ALLOW)
             }
 
             override fun onOptionalPrompt(
                 extension: WebExtension,
                 permissions: Array<out String>,
-                origins: Array<out String>
+                origins: Array<out String>,
+                optionalPermissions: Array<out String>
             ): GeckoResult<AllowOrDeny>? {
                 Log.i(TAG, "Auto-allowing optional permissions for: ${extension.metaData?.name}")
                 return GeckoResult.fromValue(AllowOrDeny.ALLOW)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-kotlin = "2.0.21"
+kotlin = "2.2.0"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
@@ -8,7 +8,7 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
-geckoview = "133.0.20241209150345"
+geckoview = "145.0.20251124145406"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Summary
- Upgrade GeckoView from 133.0 to 145.0 to fix Firefox DevTools connection issues
- Upgrade Kotlin from 2.0.21 to 2.2.0 (required dependency for GeckoView 145)
- Update WebExtensionController.PromptDelegate API for breaking changes
- Add .kotlin directory to gitignore

## Test plan
- [x] Build succeeds with `./gradlew build`
- [x] App launches and loads YouTube
- [x] Extensions still load correctly
- [x] Firefox DevTools can now connect and inspect DOM