### PR TITLE
Fix 48px gap between player and related video chips

### DIFF
--- a/app/src/main/assets/extensions/youtoob_player/scripts/src/04-styles.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/src/04-styles.js
@@ -24,6 +24,11 @@ const PLAYER_STYLES = `
         contain: none !important;
     }
 
+    /* Fix gap between player and related chips - adjust for removed 48px top bar */
+    ytm-related-chip-cloud-renderer {
+        top: calc(56.25vw + 48px) !important;
+    }
+
     /* Hide YouTube's native mobile controls */
     .player-controls-content,
     .ytp-chrome-bottom,


### PR DESCRIPTION
## Summary
- Fixes the 48px gap that appeared between the player and related video chips ("All", "From Channel", etc.)
- Adjusts the chip cloud's sticky positioning to account for YouTube's hidden top bar

## Test plan
- [ ] Open a video on YouTube mobile
- [ ] Scroll down slightly - chips should stick directly below the player with no gap
- [ ] Verify no thumbnails peek through between player and chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)