### PR TITLE
Add light mode and theme selection support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode"
             android:label="@string/app_name"
             android:theme="@style/Theme.YouToob">
             <intent-filter>

--- a/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
@@ -11,20 +11,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import com.wpinrui.youtoob.data.SettingsRepository
-import com.wpinrui.youtoob.data.YoutoobSettings
 import com.wpinrui.youtoob.ui.DownloadsActivity
 import com.wpinrui.youtoob.ui.GeckoViewScreen
 import com.wpinrui.youtoob.ui.components.YoutoobBottomNav
 import com.wpinrui.youtoob.ui.navigation.NavDestination
-import com.wpinrui.youtoob.ui.theme.YouToobTheme
+import com.wpinrui.youtoob.ui.theme.YouToobThemeWithSettings
 import com.wpinrui.youtoob.utils.isVideoPageUrl
 import org.mozilla.geckoview.GeckoSession
 
@@ -33,11 +29,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            val context = LocalContext.current
-            val settingsRepository = remember { SettingsRepository(context) }
-            val settings by settingsRepository.settings.collectAsState(initial = YoutoobSettings())
-
-            YouToobTheme(themeMode = settings.themeMode) {
+            YouToobThemeWithSettings {
                 var currentDestination by remember { mutableStateOf(NavDestination.HOME) }
                 var navigateToUrl by remember { mutableStateOf<String?>(null) }
                 var isFullscreen by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.wpinrui.youtoob
 
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -25,10 +27,22 @@ import com.wpinrui.youtoob.utils.isVideoPageUrl
 import org.mozilla.geckoview.GeckoSession
 
 class MainActivity : ComponentActivity() {
+    // Triggers recomposition when configuration changes
+    private val configVersion = mutableIntStateOf(0)
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        configVersion.intValue++
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
+            // Read configVersion to trigger recomposition on config changes
+            @Suppress("UNUSED_EXPRESSION")
+            configVersion.intValue
+
             YouToobThemeWithSettings {
                 var currentDestination by remember { mutableStateOf(NavDestination.HOME) }
                 var navigateToUrl by remember { mutableStateOf<String?>(null) }

--- a/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/MainActivity.kt
@@ -9,13 +9,17 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.wpinrui.youtoob.data.SettingsRepository
+import com.wpinrui.youtoob.data.YoutoobSettings
 import com.wpinrui.youtoob.ui.DownloadsActivity
 import com.wpinrui.youtoob.ui.GeckoViewScreen
 import com.wpinrui.youtoob.ui.components.YoutoobBottomNav
@@ -29,7 +33,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            YouToobTheme {
+            val context = LocalContext.current
+            val settingsRepository = remember { SettingsRepository(context) }
+            val settings by settingsRepository.settings.collectAsState(initial = YoutoobSettings())
+
+            YouToobTheme(themeMode = settings.themeMode) {
                 var currentDestination by remember { mutableStateOf(NavDestination.HOME) }
                 var navigateToUrl by remember { mutableStateOf<String?>(null) }
                 var isFullscreen by remember { mutableStateOf(false) }
@@ -43,9 +51,11 @@ class MainActivity : ComponentActivity() {
                     geckoSession?.goBack()
                 }
 
+                val backgroundColor = MaterialTheme.colorScheme.background
+
                 Scaffold(
-                    modifier = Modifier.fillMaxSize().background(Color.Black),
-                    containerColor = Color.Black,
+                    modifier = Modifier.fillMaxSize().background(backgroundColor),
+                    containerColor = backgroundColor,
                     bottomBar = {
                         YoutoobBottomNav(
                             currentDestination = currentDestination,

--- a/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
@@ -12,13 +12,13 @@ import kotlinx.coroutines.flow.map
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "youtoob_settings")
 
-enum class VideoQuality(val label: String, val value: String) {
-    AUTO("Auto", "auto"),
-    P480("480p", "480"),
-    P720("720p", "720"),
-    P1080("1080p", "1080"),
-    P1440("1440p", "1440"),
-    P4K("4K", "2160");
+enum class VideoQuality(val label: String, val value: String, val youtubeQuality: String) {
+    AUTO("Auto", "auto", "auto"),
+    P480("480p", "480", "large"),
+    P720("720p", "720", "hd720"),
+    P1080("1080p", "1080", "hd1080"),
+    P1440("1440p", "1440", "hd1440"),
+    P4K("4K", "2160", "hd2160");
 
     companion object {
         fun fromValue(value: String): VideoQuality =

--- a/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
@@ -40,10 +40,22 @@ enum class PlaybackSpeed(val label: String, val value: Float) {
     }
 }
 
+enum class ThemeMode(val label: String, val value: String) {
+    SYSTEM("System", "system"),
+    LIGHT("Light", "light"),
+    DARK("Dark", "dark");
+
+    companion object {
+        fun fromValue(value: String): ThemeMode =
+            entries.find { it.value == value } ?: SYSTEM
+    }
+}
+
 data class YoutoobSettings(
     val defaultQuality: VideoQuality = VideoQuality.AUTO,
     val defaultSpeed: PlaybackSpeed = PlaybackSpeed.X1,
-    val autoplayEnabled: Boolean = true
+    val autoplayEnabled: Boolean = true,
+    val themeMode: ThemeMode = ThemeMode.SYSTEM
 )
 
 class SettingsRepository(private val context: Context) {
@@ -52,6 +64,7 @@ class SettingsRepository(private val context: Context) {
         val DEFAULT_QUALITY = stringPreferencesKey("default_quality")
         val DEFAULT_SPEED = stringPreferencesKey("default_speed")
         val AUTOPLAY_ENABLED = booleanPreferencesKey("autoplay_enabled")
+        val THEME_MODE = stringPreferencesKey("theme_mode")
     }
 
     val settings: Flow<YoutoobSettings> = context.dataStore.data.map { preferences ->
@@ -62,7 +75,10 @@ class SettingsRepository(private val context: Context) {
             defaultSpeed = PlaybackSpeed.fromValue(
                 preferences[PreferenceKeys.DEFAULT_SPEED]?.toFloatOrNull() ?: PlaybackSpeed.X1.value
             ),
-            autoplayEnabled = preferences[PreferenceKeys.AUTOPLAY_ENABLED] ?: true
+            autoplayEnabled = preferences[PreferenceKeys.AUTOPLAY_ENABLED] ?: true,
+            themeMode = ThemeMode.fromValue(
+                preferences[PreferenceKeys.THEME_MODE] ?: ThemeMode.SYSTEM.value
+            )
         )
     }
 
@@ -81,6 +97,12 @@ class SettingsRepository(private val context: Context) {
     suspend fun setAutoplayEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[PreferenceKeys.AUTOPLAY_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setThemeMode(mode: ThemeMode) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferenceKeys.THEME_MODE] = mode.value
         }
     }
 }

--- a/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/data/SettingsRepository.kt
@@ -45,6 +45,12 @@ enum class ThemeMode(val label: String, val value: String) {
     LIGHT("Light", "light"),
     DARK("Dark", "dark");
 
+    fun isDark(systemIsDark: Boolean): Boolean = when (this) {
+        LIGHT -> false
+        DARK -> true
+        SYSTEM -> systemIsDark
+    }
+
     companion object {
         fun fromValue(value: String): ThemeMode =
             entries.find { it.value == value } ?: SYSTEM

--- a/app/src/main/java/com/wpinrui/youtoob/ui/DownloadsActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/DownloadsActivity.kt
@@ -16,15 +16,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import com.wpinrui.youtoob.data.SettingsRepository
-import com.wpinrui.youtoob.data.YoutoobSettings
-import com.wpinrui.youtoob.ui.theme.YouToobTheme
+import com.wpinrui.youtoob.ui.theme.YouToobThemeWithSettings
 
 class DownloadsActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -32,11 +26,7 @@ class DownloadsActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            val context = LocalContext.current
-            val settingsRepository = remember { SettingsRepository(context) }
-            val settings by settingsRepository.settings.collectAsState(initial = YoutoobSettings())
-
-            YouToobTheme(themeMode = settings.themeMode) {
+            YouToobThemeWithSettings {
                 Scaffold(
                     topBar = {
                         TopAppBar(

--- a/app/src/main/java/com/wpinrui/youtoob/ui/DownloadsActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/DownloadsActivity.kt
@@ -16,8 +16,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.wpinrui.youtoob.data.SettingsRepository
+import com.wpinrui.youtoob.data.YoutoobSettings
 import com.wpinrui.youtoob.ui.theme.YouToobTheme
 
 class DownloadsActivity : ComponentActivity() {
@@ -26,7 +32,11 @@ class DownloadsActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            YouToobTheme {
+            val context = LocalContext.current
+            val settingsRepository = remember { SettingsRepository(context) }
+            val settings by settingsRepository.settings.collectAsState(initial = YoutoobSettings())
+
+            YouToobTheme(themeMode = settings.themeMode) {
                 Scaffold(
                     topBar = {
                         TopAppBar(

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -298,6 +298,14 @@ fun GeckoViewScreen(
     }
 
     val isDark = cachedSettings.themeMode.isDark(systemIsDark)
+
+    // Reload page when theme changes to re-apply CSS
+    var previousIsDark by remember { mutableStateOf(isDark) }
+    if (isDark != previousIsDark) {
+        previousIsDark = isDark
+        session.reload()
+    }
+
     val coverColor = if (isDark) android.graphics.Color.BLACK else android.graphics.Color.WHITE
 
     AndroidView(

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -194,8 +195,7 @@ fun GeckoViewScreen(
 
     // Track system dark mode for theme-aware CSS injection
     val systemIsDark = isSystemInDarkTheme()
-    val systemIsDarkRef = remember { mutableStateOf(true) }
-    systemIsDarkRef.value = systemIsDark
+    val currentSystemIsDark by rememberUpdatedState(systemIsDark)
 
     val permissionBridge = remember { PermissionBridge() }
     var pendingPermissionCallback by remember { mutableStateOf<((Map<String, Boolean>) -> Unit)?>(null) }
@@ -238,7 +238,7 @@ fun GeckoViewScreen(
             },
             permissionBridge = permissionBridge,
             onPageLoaded = { session ->
-                val isDark = cachedSettings.themeMode.isDark(systemIsDarkRef.value)
+                val isDark = cachedSettings.themeMode.isDark(currentSystemIsDark)
                 injectCss(session, currentUrl.isVideoPageUrl(), isDark)
                 if (currentUrl.isVideoPageUrl()) {
                     injectSettings(session, cachedSettings)
@@ -252,7 +252,7 @@ fun GeckoViewScreen(
                 // Re-inject CSS on SPA navigation when video page state changes
                 if (isVideoPage != wasVideoPage) {
                     Handler(Looper.getMainLooper()).postDelayed({
-                        val isDark = cachedSettings.themeMode.isDark(systemIsDarkRef.value)
+                        val isDark = cachedSettings.themeMode.isDark(currentSystemIsDark)
                         injectCss(session, isVideoPage, isDark)
                     }, SPA_NAVIGATION_DELAY_MS)
                 }

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -301,7 +301,8 @@ fun GeckoViewScreen(
         }
     }
 
-    val coverColor = if (systemIsDark) android.graphics.Color.BLACK else android.graphics.Color.WHITE
+    val isDark = cachedSettings.themeMode.isDark(systemIsDark)
+    val coverColor = if (isDark) android.graphics.Color.BLACK else android.graphics.Color.WHITE
 
     AndroidView(
         factory = { ctx ->

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -85,6 +85,12 @@ private fun getBaseCss(isDark: Boolean): String {
         .published-time {
             color: $secondaryTextColor !important;
         }
+
+        /* Selected chips have light background - need dark text for contrast */
+        ytm-chip-cloud-chip-renderer.selected .yt-core-attributed-string,
+        ytm-chip-cloud-chip-renderer[aria-selected="true"] .yt-core-attributed-string {
+            color: #0f0f0f !important;
+        }
     """.trimIndent()
 }
 

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -238,11 +238,7 @@ fun GeckoViewScreen(
             },
             permissionBridge = permissionBridge,
             onPageLoaded = { session ->
-                val isDark = when (cachedSettings.themeMode) {
-                    ThemeMode.LIGHT -> false
-                    ThemeMode.DARK -> true
-                    ThemeMode.SYSTEM -> systemIsDarkRef.value
-                }
+                val isDark = cachedSettings.themeMode.isDark(systemIsDarkRef.value)
                 injectCss(session, currentUrl.isVideoPageUrl(), isDark)
                 if (currentUrl.isVideoPageUrl()) {
                     injectSettings(session, cachedSettings)
@@ -256,11 +252,7 @@ fun GeckoViewScreen(
                 // Re-inject CSS on SPA navigation when video page state changes
                 if (isVideoPage != wasVideoPage) {
                     Handler(Looper.getMainLooper()).postDelayed({
-                        val isDark = when (cachedSettings.themeMode) {
-                            ThemeMode.LIGHT -> false
-                            ThemeMode.DARK -> true
-                            ThemeMode.SYSTEM -> systemIsDarkRef.value
-                        }
+                        val isDark = cachedSettings.themeMode.isDark(systemIsDarkRef.value)
                         injectCss(session, isVideoPage, isDark)
                     }, SPA_NAVIGATION_DELAY_MS)
                 }

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -44,6 +44,9 @@ private const val SPA_NAVIGATION_DELAY_MS = 1000L
 
 private fun getBaseCss(isDark: Boolean): String {
     val backgroundColor = if (isDark) "#000" else "#fff"
+    val textColor = if (isDark) "#fff" else "#0f0f0f"
+    val secondaryTextColor = if (isDark) "#aaa" else "#606060"
+
     return """
         /* Hide YouTube bottom navigation */
         ytm-pivot-bar-renderer,
@@ -57,6 +60,29 @@ private fun getBaseCss(isDark: Boolean): String {
         /* Theme-aware background */
         html, body, ytm-app, ytm-browse, ytm-watch {
             background-color: $backgroundColor !important;
+        }
+
+        /* Theme-aware text colors for light mode */
+        ytm-rich-item-renderer,
+        ytm-video-with-context-renderer,
+        ytm-compact-video-renderer,
+        ytm-reel-item-renderer,
+        .media-item-headline,
+        .media-item-metadata,
+        .video-title,
+        .channel-name,
+        h3, h4,
+        ytm-badge-and-byline-renderer,
+        .yt-core-attributed-string {
+            color: $textColor !important;
+        }
+
+        /* Secondary text (views, time, etc) */
+        .media-item-byline,
+        .ytm-badge-and-byline-renderer span,
+        .view-count,
+        .published-time {
+            color: $secondaryTextColor !important;
         }
     """.trimIndent()
 }

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -141,20 +141,10 @@ private fun injectCss(session: GeckoSession, isVideoPage: Boolean, isDark: Boole
 }
 
 private fun injectSettings(session: GeckoSession, settings: YoutoobSettings) {
-    val qualityMap = mapOf(
-        "auto" to "auto",
-        "480" to "large",
-        "720" to "hd720",
-        "1080" to "hd1080",
-        "1440" to "hd1440",
-        "2160" to "hd2160"
-    )
-    val ytQuality = qualityMap[settings.defaultQuality.value] ?: "auto"
-
     val settingsScript = """
         (function() {
             window._youtoobSettings = {
-                defaultQuality: '$ytQuality',
+                defaultQuality: '${settings.defaultQuality.youtubeQuality}',
                 defaultSpeed: ${settings.defaultSpeed.value},
                 autoplayEnabled: ${settings.autoplayEnabled}
             };

--- a/app/src/main/java/com/wpinrui/youtoob/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/SettingsActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.wpinrui.youtoob.data.PlaybackSpeed
 import com.wpinrui.youtoob.data.SettingsRepository
+import com.wpinrui.youtoob.data.ThemeMode
 import com.wpinrui.youtoob.data.VideoQuality
 import com.wpinrui.youtoob.data.YoutoobSettings
 import com.wpinrui.youtoob.ui.theme.YouToobTheme
@@ -48,11 +49,12 @@ class SettingsActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            YouToobTheme(darkTheme = true, dynamicColor = false) {
-                val context = LocalContext.current
-                val repository = remember { SettingsRepository(context) }
-                val settings by repository.settings.collectAsState(initial = YoutoobSettings())
-                val scope = rememberCoroutineScope()
+            val context = LocalContext.current
+            val repository = remember { SettingsRepository(context) }
+            val settings by repository.settings.collectAsState(initial = YoutoobSettings())
+            val scope = rememberCoroutineScope()
+
+            YouToobTheme(themeMode = settings.themeMode) {
 
                 Scaffold(
                     topBar = {
@@ -76,6 +78,23 @@ class SettingsActivity : ComponentActivity() {
                             .padding(innerPadding)
                             .padding(16.dp)
                     ) {
+                        SettingsHeader("Appearance")
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        DropdownSetting(
+                            title = "Theme",
+                            subtitle = settings.themeMode.label,
+                            options = ThemeMode.entries.map { it.label },
+                            selectedIndex = ThemeMode.entries.indexOf(settings.themeMode),
+                            onSelect = { index ->
+                                scope.launch {
+                                    repository.setThemeMode(ThemeMode.entries[index])
+                                }
+                            }
+                        )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
                         SettingsHeader("Playback")
                         Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/com/wpinrui/youtoob/ui/components/YoutoobBottomNav.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/components/YoutoobBottomNav.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
@@ -29,10 +30,11 @@ fun YoutoobBottomNav(
         modifier = modifier
     ) {
         NavigationBar(
-            containerColor = Color.Black,
-            contentColor = Color.White,
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
             windowInsets = WindowInsets(0.dp)
         ) {
+            val contentColor = MaterialTheme.colorScheme.onSurface
             NavDestination.entries.forEach { destination ->
                 val isSelected = currentDestination == destination
                 NavigationBarItem(
@@ -46,10 +48,10 @@ fun YoutoobBottomNav(
                     selected = isSelected,
                     onClick = { onNavigate(destination) },
                     colors = NavigationBarItemDefaults.colors(
-                        selectedIconColor = Color.White,
-                        selectedTextColor = Color.White,
-                        unselectedIconColor = Color.White.copy(alpha = 0.7f),
-                        unselectedTextColor = Color.White.copy(alpha = 0.7f),
+                        selectedIconColor = contentColor,
+                        selectedTextColor = contentColor,
+                        unselectedIconColor = contentColor.copy(alpha = 0.7f),
+                        unselectedTextColor = contentColor.copy(alpha = 0.7f),
                         indicatorColor = Color.Transparent
                     )
                 )

--- a/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
@@ -43,11 +43,7 @@ fun YouToobTheme(
     content: @Composable () -> Unit
 ) {
     val systemIsDark = isSystemInDarkTheme()
-    val isDark = when (themeMode) {
-        ThemeMode.LIGHT -> false
-        ThemeMode.DARK -> true
-        ThemeMode.SYSTEM -> systemIsDark
-    }
+    val isDark = themeMode.isDark(systemIsDark)
 
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {

--- a/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
@@ -8,9 +8,14 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.wpinrui.youtoob.data.SettingsRepository
 import com.wpinrui.youtoob.data.ThemeMode
+import com.wpinrui.youtoob.data.YoutoobSettings
 
 private val PureBlack = Color(0xFF000000)
 
@@ -59,4 +64,14 @@ fun YouToobTheme(
         typography = Typography,
         content = content
     )
+}
+
+@Composable
+fun YouToobThemeWithSettings(
+    content: @Composable () -> Unit
+) {
+    val context = LocalContext.current
+    val settingsRepository = remember { SettingsRepository(context) }
+    val settings by settingsRepository.settings.collectAsState(initial = YoutoobSettings())
+    YouToobTheme(themeMode = settings.themeMode, content = content)
 }

--- a/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.wpinrui.youtoob.data.ThemeMode
 
 private val PureBlack = Color(0xFF000000)
 
@@ -22,26 +23,38 @@ private val DarkColorScheme = darkColorScheme(
     surfaceVariant = Color(0xFF1A1A1A)
 )
 
+private val PureWhite = Color(0xFFFFFFFF)
+
 private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
-    tertiary = Pink40
+    tertiary = Pink40,
+    background = PureWhite,
+    surface = PureWhite,
+    surfaceVariant = Color(0xFFF5F5F5),
+    onBackground = Color(0xFF1C1B1F),
+    onSurface = Color(0xFF1C1B1F)
 )
 
 @Composable
 fun YouToobTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
+    val systemIsDark = isSystemInDarkTheme()
+    val isDark = when (themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+        ThemeMode.SYSTEM -> systemIsDark
+    }
+
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            if (isDark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
-        darkTheme -> DarkColorScheme
+        isDark -> DarkColorScheme
         else -> LightColorScheme
     }
 

--- a/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/theme/Theme.kt
@@ -1,5 +1,6 @@
 package com.wpinrui.youtoob.ui.theme
 
+import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -8,11 +9,13 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.view.WindowCompat
 import com.wpinrui.youtoob.data.SettingsRepository
 import com.wpinrui.youtoob.data.ThemeMode
 import com.wpinrui.youtoob.data.YoutoobSettings
@@ -57,6 +60,17 @@ fun YouToobTheme(
         }
         isDark -> DarkColorScheme
         else -> LightColorScheme
+    }
+
+    // Update status bar and navigation bar icons color
+    val context = LocalContext.current
+    val activity = context as? Activity
+    SideEffect {
+        activity?.let {
+            val controller = WindowCompat.getInsetsController(it.window, it.window.decorView)
+            controller.isAppearanceLightStatusBars = !isDark
+            controller.isAppearanceLightNavigationBars = !isDark
+        }
     }
 
     MaterialTheme(

--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,8 @@ YouToob wraps YouTube's mobile site in Firefox's GeckoView engine, enabling Fire
 - [ ] Implement gesture controls (swipe for volume/brightness)
 - [ ] Add custom playback controls (YouTube mobile-style overlay)
 - [x] Hide unnecessary YouTube UI elements (via CSS injection)
-- [ ] Create settings screen for app customization
-- [ ] Implement custom theming
+- [x] Create settings screen for app customization
+- [x] Implement custom theming
 
 **Estimated**: 2 weeks
 


### PR DESCRIPTION
## Summary
- Add theme selection setting with three options: System (default), Light, Dark
- Update all activities and components to respect theme preference
- Add theme-aware CSS injection for YouTube content

## Changes
- Added `ThemeMode` enum to SettingsRepository with DataStore persistence
- Updated `YouToobTheme` to accept ThemeMode parameter
- Added theme dropdown in Settings under new "Appearance" section
- Fixed hardcoded dark colors in MainActivity, YoutoobBottomNav, DownloadsActivity
- Made GeckoView CSS injection theme-aware (white/black backgrounds)

## Testing
- [x] Build succeeds
- [x] Theme switches immediately without restart
- [x] System theme option follows device dark mode setting
- [x] YouTube content background matches app theme

Closes #19