### PR TITLE
Add background audio playback with media notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ android {
 dependencies {
     implementation(libs.geckoview)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.media)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="true"
@@ -40,6 +43,11 @@
             android:exported="false"
             android:label="Settings"
             android:theme="@style/Theme.YouToob" />
+
+        <service
+            android:name=".media.AudioPlaybackService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
     </application>
 
 </manifest>

--- a/app/src/main/assets/extensions/video_bg_play/_locales/en/messages.json
+++ b/app/src/main/assets/extensions/video_bg_play/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extensionName": {
+    "message": "Video Background Play Fix",
+    "description": "Name of the extension."
+  },
+  "extensionDescription": {
+    "message": "Play back videos in background even if a page doesn't want you to.",
+    "description": "Description of the extension."
+  }
+}

--- a/app/src/main/assets/extensions/video_bg_play/manifest.json
+++ b/app/src/main/assets/extensions/video_bg_play/manifest.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 2,
+  "name": "__MSG_extensionName__",
+  "default_locale": "en",
+  "version": "1.8.1",
+  "description": "__MSG_extensionDescription__",
+  "applications": {
+    "gecko": {
+      "id": "video-bg-play@timdream.org",
+      "strict_min_version": "58.0"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.youtube.com/*",
+        "*://*.youtube-nocookie.com/*",
+        "*://*.vimeo.com/*"
+      ],
+      "js": ["video-bg-play-content.js"],
+      "all_frames": true
+    }
+  ]
+}

--- a/app/src/main/assets/extensions/video_bg_play/video-bg-play-content.js
+++ b/app/src/main/assets/extensions/video_bg_play/video-bg-play-content.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const IS_YOUTUBE = window.location.hostname.search(/(?:^|.+\.)youtube\.com/) > -1 ||
+                   window.location.hostname.search(/(?:^|.+\.)youtube-nocookie\.com/) > -1;
+const IS_MOBILE_YOUTUBE = window.location.hostname == 'm.youtube.com';
+const IS_DESKTOP_YOUTUBE = IS_YOUTUBE && !IS_MOBILE_YOUTUBE;
+const IS_VIMEO = window.location.hostname.search(/(?:^|.+\.)vimeo\.com/) > -1;
+
+const IS_ANDROID = window.navigator.userAgent.indexOf('Android') > -1;
+
+// Page Visibility API
+if (IS_ANDROID || !IS_DESKTOP_YOUTUBE) {
+  Object.defineProperties(document.wrappedJSObject,
+    { 'hidden': {value: false}, 'visibilityState': {value: 'visible'} });
+}
+
+window.addEventListener(
+  'visibilitychange', evt => evt.stopImmediatePropagation(), true);
+
+// Fullscreen API
+if (IS_VIMEO) {
+  window.addEventListener(
+    'fullscreenchange', evt => evt.stopImmediatePropagation(), true);
+}
+
+// User activity tracking
+if (IS_YOUTUBE) {
+  loop(pressKey, 60 * 1000, 10 * 1000); // every minute +/- 5 seconds
+}
+
+function pressKey() {
+  const keyCodes = [18];
+  let key = keyCodes[getRandomInt(0, keyCodes.length)];
+  sendKeyEvent("keydown", key);
+  sendKeyEvent("keyup", key);
+}
+
+function sendKeyEvent (aEvent, aKey) {
+  document.dispatchEvent(new KeyboardEvent(aEvent, {
+    bubbles: true,
+    cancelable: true,
+    keyCode: aKey,
+    which: aKey,
+  }));
+}
+
+function loop(aCallback, aDelay, aJitter) {
+  let jitter = getRandomInt(-aJitter/2, aJitter/2);
+  let delay = Math.max(aDelay + jitter, 0);
+
+  window.setTimeout(() => {
+                      aCallback();
+                      loop(aCallback, aDelay, aJitter);
+                    }, delay);
+}
+
+function getRandomInt(aMin, aMax) {
+  let min = Math.ceil(aMin);
+  let max = Math.floor(aMax);
+  return Math.floor(Math.random() * (max - min)) + min;
+}

--- a/app/src/main/java/com/wpinrui/youtoob/extensions/ExtensionConfig.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/extensions/ExtensionConfig.kt
@@ -29,6 +29,12 @@ enum class BundledExtension(
         displayName = "YouToob Player Controls",
         folderName = "youtoob_player",
         defaultEnabled = true
+    ),
+    VIDEO_BG_PLAY(
+        id = "video-bg-play@timdream.org",
+        displayName = "Video Background Play Fix",
+        folderName = "video_bg_play",
+        defaultEnabled = true
     );
 
     val builtInUri: String

--- a/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
@@ -13,6 +13,7 @@ data class MediaInfo(val title: String?, val artist: String?)
 private const val YOUTOOB_SCHEME = "youtoob"
 private const val GOBACK_ACTION = "goback"
 private const val SETTINGS_ACTION = "settings"
+private const val ARTWORK_BITMAP_SIZE = 256
 
 class GeckoSessionDelegate(
     private val onFullscreenChange: (Boolean) -> Unit,
@@ -111,7 +112,7 @@ class GeckoSessionDelegate(
         onMediaMetadata(MediaInfo(metadata.title, metadata.artist))
 
         // Load artwork bitmap asynchronously
-        metadata.artwork?.getBitmap(256)?.accept({ bitmap ->
+        metadata.artwork?.getBitmap(ARTWORK_BITMAP_SIZE)?.accept({ bitmap ->
             bitmap?.let { onMediaArtwork(it) }
         }, { /* Ignore errors */ })
     }

--- a/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
@@ -17,6 +17,7 @@ private const val SETTINGS_ACTION = "settings"
 class GeckoSessionDelegate(
     private val onFullscreenChange: (Boolean) -> Unit,
     private val onMediaPlaying: (MediaSession) -> Unit,
+    private val onMediaPaused: () -> Unit = {},
     private val onMediaStopped: () -> Unit,
     private val onMediaMetadata: (MediaInfo) -> Unit = {},
     private val onMediaArtwork: (Bitmap) -> Unit = {},
@@ -95,7 +96,7 @@ class GeckoSessionDelegate(
     }
 
     override fun onPause(session: GeckoSession, mediaSession: MediaSession) {
-        onMediaStopped()
+        onMediaPaused()
     }
 
     override fun onStop(session: GeckoSession, mediaSession: MediaSession) {

--- a/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
@@ -7,6 +7,7 @@ import org.mozilla.geckoview.MediaSession
 import com.wpinrui.youtoob.utils.PermissionBridge
 
 data class ShareRequest(val title: String?, val text: String?, val uri: String?)
+data class MediaInfo(val title: String?, val artist: String?)
 
 private const val YOUTOOB_SCHEME = "youtoob"
 private const val GOBACK_ACTION = "goback"
@@ -16,6 +17,7 @@ class GeckoSessionDelegate(
     private val onFullscreenChange: (Boolean) -> Unit,
     private val onMediaPlaying: () -> Unit,
     private val onMediaStopped: () -> Unit,
+    private val onMediaMetadata: (MediaInfo) -> Unit = {},
     private val permissionBridge: PermissionBridge,
     private val onPageLoaded: (GeckoSession) -> Unit = {},
     private val onUrlChange: (String, GeckoSession) -> Unit = { _, _ -> },
@@ -96,6 +98,14 @@ class GeckoSessionDelegate(
 
     override fun onStop(session: GeckoSession, mediaSession: MediaSession) {
         onMediaStopped()
+    }
+
+    override fun onMetadata(
+        session: GeckoSession,
+        mediaSession: MediaSession,
+        metadata: MediaSession.Metadata
+    ) {
+        onMediaMetadata(MediaInfo(metadata.title, metadata.artist))
     }
 
     // ProgressDelegate - Detect page loads for CSS injection

--- a/app/src/main/java/com/wpinrui/youtoob/media/AudioPlaybackService.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/media/AudioPlaybackService.kt
@@ -70,6 +70,18 @@ class AudioPlaybackService : Service() {
                 updatePlaybackState()
                 updateNotification()
             }
+            ACTION_SET_PLAYING -> {
+                // Update UI state only, no broadcast (used when GeckoView already changed state)
+                isPlaying = true
+                updatePlaybackState()
+                updateNotification()
+            }
+            ACTION_SET_PAUSED -> {
+                // Update UI state only, no broadcast (used when GeckoView already changed state)
+                isPlaying = false
+                updatePlaybackState()
+                updateNotification()
+            }
             ACTION_NEXT -> {
                 sendBroadcast(Intent(BROADCAST_NEXT))
             }
@@ -277,6 +289,8 @@ class AudioPlaybackService : Service() {
         const val ACTION_UPDATE_ARTWORK = "com.wpinrui.youtoob.UPDATE_ARTWORK"
         const val ACTION_PLAY = "com.wpinrui.youtoob.PLAY"
         const val ACTION_PAUSE = "com.wpinrui.youtoob.PAUSE"
+        const val ACTION_SET_PLAYING = "com.wpinrui.youtoob.SET_PLAYING"
+        const val ACTION_SET_PAUSED = "com.wpinrui.youtoob.SET_PAUSED"
         const val ACTION_NEXT = "com.wpinrui.youtoob.NEXT"
         const val ACTION_PREVIOUS = "com.wpinrui.youtoob.PREVIOUS"
         const val ACTION_STOP = "com.wpinrui.youtoob.STOP"
@@ -324,6 +338,20 @@ class AudioPlaybackService : Service() {
         fun stop(context: Context) {
             val intent = Intent(context, AudioPlaybackService::class.java).apply {
                 action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+
+        fun setPlaying(context: Context) {
+            val intent = Intent(context, AudioPlaybackService::class.java).apply {
+                action = ACTION_SET_PLAYING
+            }
+            context.startService(intent)
+        }
+
+        fun setPaused(context: Context) {
+            val intent = Intent(context, AudioPlaybackService::class.java).apply {
+                action = ACTION_SET_PAUSED
             }
             context.startService(intent)
         }

--- a/app/src/main/java/com/wpinrui/youtoob/media/AudioPlaybackService.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/media/AudioPlaybackService.kt
@@ -24,8 +24,8 @@ class AudioPlaybackService : Service() {
     private lateinit var mediaSession: MediaSessionCompat
     private lateinit var notificationManager: NotificationManager
 
-    private var currentTitle: String = "Playing"
-    private var currentArtist: String = "YouToob"
+    private var currentTitle: String = DEFAULT_TITLE
+    private var currentArtist: String = DEFAULT_ARTIST
     private var currentArtwork: Bitmap? = null
     private var isPlaying: Boolean = true
 
@@ -39,8 +39,8 @@ class AudioPlaybackService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_START -> {
-                currentTitle = intent.getStringExtra(EXTRA_TITLE) ?: "Playing"
-                currentArtist = intent.getStringExtra(EXTRA_ARTIST) ?: "YouToob"
+                currentTitle = intent.getStringExtra(EXTRA_TITLE) ?: DEFAULT_TITLE
+                currentArtist = intent.getStringExtra(EXTRA_ARTIST) ?: DEFAULT_ARTIST
                 isPlaying = true
                 startForegroundService()
             }
@@ -283,6 +283,8 @@ class AudioPlaybackService : Service() {
     companion object {
         private const val CHANNEL_ID = "youtoob_playback"
         private const val NOTIFICATION_ID = 1
+        private const val DEFAULT_TITLE = "Playing"
+        private const val DEFAULT_ARTIST = "YouToob"
 
         const val ACTION_START = "com.wpinrui.youtoob.START"
         const val ACTION_UPDATE_METADATA = "com.wpinrui.youtoob.UPDATE_METADATA"

--- a/app/src/main/java/com/wpinrui/youtoob/media/AudioPlaybackService.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/media/AudioPlaybackService.kt
@@ -1,0 +1,268 @@
+package com.wpinrui.youtoob.media
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.graphics.Bitmap
+import android.os.Build
+import android.os.IBinder
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.media.app.NotificationCompat.MediaStyle
+import com.wpinrui.youtoob.MainActivity
+import com.wpinrui.youtoob.R
+
+class AudioPlaybackService : Service() {
+
+    private lateinit var mediaSession: MediaSessionCompat
+    private lateinit var notificationManager: NotificationManager
+
+    private var currentTitle: String = "Playing"
+    private var currentArtist: String = "YouToob"
+    private var currentArtwork: Bitmap? = null
+    private var isPlaying: Boolean = true
+
+    override fun onCreate() {
+        super.onCreate()
+        notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        createNotificationChannel()
+        setupMediaSession()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> {
+                currentTitle = intent.getStringExtra(EXTRA_TITLE) ?: "Playing"
+                currentArtist = intent.getStringExtra(EXTRA_ARTIST) ?: "YouToob"
+                isPlaying = true
+                startForegroundService()
+            }
+            ACTION_UPDATE_METADATA -> {
+                currentTitle = intent.getStringExtra(EXTRA_TITLE) ?: currentTitle
+                currentArtist = intent.getStringExtra(EXTRA_ARTIST) ?: currentArtist
+                updateNotification()
+                updateMediaSessionMetadata()
+            }
+            ACTION_PLAY -> {
+                isPlaying = true
+                updatePlaybackState()
+                updateNotification()
+            }
+            ACTION_PAUSE -> {
+                isPlaying = false
+                updatePlaybackState()
+                updateNotification()
+            }
+            ACTION_STOP -> {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+            }
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        mediaSession.release()
+        super.onDestroy()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Media Playback",
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = "Shows media playback controls"
+            setShowBadge(false)
+        }
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun setupMediaSession() {
+        mediaSession = MediaSessionCompat(this, "YouToobMediaSession").apply {
+            setCallback(object : MediaSessionCompat.Callback() {
+                override fun onPlay() {
+                    sendBroadcast(Intent(BROADCAST_PLAY))
+                }
+
+                override fun onPause() {
+                    sendBroadcast(Intent(BROADCAST_PAUSE))
+                }
+
+                override fun onStop() {
+                    sendBroadcast(Intent(BROADCAST_STOP))
+                }
+
+                override fun onSeekTo(pos: Long) {
+                    sendBroadcast(Intent(BROADCAST_SEEK).putExtra(EXTRA_POSITION, pos))
+                }
+            })
+            isActive = true
+        }
+        updateMediaSessionMetadata()
+        updatePlaybackState()
+    }
+
+    private fun updateMediaSessionMetadata() {
+        val metadata = MediaMetadataCompat.Builder()
+            .putString(MediaMetadataCompat.METADATA_KEY_TITLE, currentTitle)
+            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, currentArtist)
+            .apply {
+                currentArtwork?.let {
+                    putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, it)
+                }
+            }
+            .build()
+        mediaSession.setMetadata(metadata)
+    }
+
+    private fun updatePlaybackState() {
+        val state = if (isPlaying) {
+            PlaybackStateCompat.STATE_PLAYING
+        } else {
+            PlaybackStateCompat.STATE_PAUSED
+        }
+
+        val playbackState = PlaybackStateCompat.Builder()
+            .setActions(
+                PlaybackStateCompat.ACTION_PLAY or
+                PlaybackStateCompat.ACTION_PAUSE or
+                PlaybackStateCompat.ACTION_STOP or
+                PlaybackStateCompat.ACTION_SEEK_TO
+            )
+            .setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 1f)
+            .build()
+        mediaSession.setPlaybackState(playbackState)
+    }
+
+    private fun startForegroundService() {
+        val notification = buildNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun updateNotification() {
+        notificationManager.notify(NOTIFICATION_ID, buildNotification())
+    }
+
+    private fun buildNotification(): Notification {
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val playPauseAction = if (isPlaying) {
+            NotificationCompat.Action(
+                R.drawable.ic_pause,
+                "Pause",
+                getPendingIntent(ACTION_PAUSE)
+            )
+        } else {
+            NotificationCompat.Action(
+                R.drawable.ic_play,
+                "Play",
+                getPendingIntent(ACTION_PLAY)
+            )
+        }
+
+        val stopAction = NotificationCompat.Action(
+            R.drawable.ic_stop,
+            "Stop",
+            getPendingIntent(ACTION_STOP)
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(currentTitle)
+            .setContentText(currentArtist)
+            .setContentIntent(contentIntent)
+            .setOngoing(true)
+            .setShowWhen(false)
+            .addAction(playPauseAction)
+            .addAction(stopAction)
+            .setStyle(
+                MediaStyle()
+                    .setMediaSession(mediaSession.sessionToken)
+                    .setShowActionsInCompactView(0, 1)
+            )
+            .apply {
+                currentArtwork?.let { setLargeIcon(it) }
+            }
+            .build()
+    }
+
+    private fun getPendingIntent(action: String): PendingIntent {
+        val intent = Intent(this, AudioPlaybackService::class.java).apply {
+            this.action = action
+        }
+        return PendingIntent.getService(
+            this,
+            action.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    companion object {
+        private const val TAG = "YTB_AudioService"
+        private const val CHANNEL_ID = "youtoob_playback"
+        private const val NOTIFICATION_ID = 1
+
+        const val ACTION_START = "com.wpinrui.youtoob.START"
+        const val ACTION_UPDATE_METADATA = "com.wpinrui.youtoob.UPDATE_METADATA"
+        const val ACTION_PLAY = "com.wpinrui.youtoob.PLAY"
+        const val ACTION_PAUSE = "com.wpinrui.youtoob.PAUSE"
+        const val ACTION_STOP = "com.wpinrui.youtoob.STOP"
+
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_ARTIST = "artist"
+        const val EXTRA_POSITION = "position"
+
+        const val BROADCAST_PLAY = "com.wpinrui.youtoob.BROADCAST_PLAY"
+        const val BROADCAST_PAUSE = "com.wpinrui.youtoob.BROADCAST_PAUSE"
+        const val BROADCAST_STOP = "com.wpinrui.youtoob.BROADCAST_STOP"
+        const val BROADCAST_SEEK = "com.wpinrui.youtoob.BROADCAST_SEEK"
+
+        fun start(context: Context, title: String? = null, artist: String? = null) {
+            val intent = Intent(context, AudioPlaybackService::class.java).apply {
+                action = ACTION_START
+                title?.let { putExtra(EXTRA_TITLE, it) }
+                artist?.let { putExtra(EXTRA_ARTIST, it) }
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun updateMetadata(context: Context, title: String?, artist: String?) {
+            val intent = Intent(context, AudioPlaybackService::class.java).apply {
+                action = ACTION_UPDATE_METADATA
+                title?.let { putExtra(EXTRA_TITLE, it) }
+                artist?.let { putExtra(EXTRA_ARTIST, it) }
+            }
+            context.startService(intent)
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, AudioPlaybackService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -350,13 +350,13 @@ fun GeckoViewScreen(
     DisposableEffect(activeMediaSession) {
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(ctx: Context?, intent: Intent?) {
-                val session = activeMediaSession ?: return
+                val mediaSession = activeMediaSession ?: return
                 when (intent?.action) {
-                    AudioPlaybackService.BROADCAST_PLAY -> session.play()
-                    AudioPlaybackService.BROADCAST_PAUSE -> session.pause()
-                    AudioPlaybackService.BROADCAST_STOP -> session.stop()
-                    AudioPlaybackService.BROADCAST_NEXT -> session.nextTrack()
-                    AudioPlaybackService.BROADCAST_PREVIOUS -> session.previousTrack()
+                    AudioPlaybackService.BROADCAST_PLAY -> mediaSession.play()
+                    AudioPlaybackService.BROADCAST_PAUSE -> mediaSession.pause()
+                    AudioPlaybackService.BROADCAST_STOP -> mediaSession.stop()
+                    AudioPlaybackService.BROADCAST_NEXT -> mediaSession.nextTrack()
+                    AudioPlaybackService.BROADCAST_PREVIOUS -> mediaSession.previousTrack()
                 }
             }
         }

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -265,6 +265,15 @@ fun GeckoViewScreen(
                 if (!isMediaServiceRunning) {
                     AudioPlaybackService.start(context)
                     isMediaServiceRunning = true
+                } else {
+                    // Already running, just update to playing state
+                    AudioPlaybackService.setPlaying(context)
+                }
+            },
+            onMediaPaused = {
+                // Keep service running, just update notification to paused state
+                if (isMediaServiceRunning) {
+                    AudioPlaybackService.setPaused(context)
                 }
             },
             onMediaStopped = {

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.getSystemService
 import com.wpinrui.youtoob.data.SettingsRepository
-import com.wpinrui.youtoob.data.ThemeMode
 import com.wpinrui.youtoob.data.YoutoobSettings
 import com.wpinrui.youtoob.gecko.GeckoRuntimeProvider
 import com.wpinrui.youtoob.gecko.GeckoSessionDelegate

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM9.5,16.5v-9l7,4.5 -7,4.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_pause.xml
+++ b/app/src/main/res/drawable/ic_pause.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,19h4V5H6v14zM14,5v14h4V5h-4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_play.xml
+++ b/app/src/main/res/drawable/ic_play.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M8,5v14l11,-7z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_skip_next.xml
+++ b/app/src/main/res/drawable/ic_skip_next.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_skip_previous.xml
+++ b/app/src/main/res/drawable/ic_skip_previous.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,6h2v12H6V6zM9.5,12l8.5,6V6L9.5,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,6h12v12H6z"/>
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 geckoview = "145.0.20251124145406"
 datastore = "1.1.1"
+media = "1.6.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,7 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 geckoview = { group = "org.mozilla.geckoview", name = "geckoview", version.ref = "geckoview" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+androidx-media = { group = "androidx.media", name = "media", version.ref = "media" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Bundle Mozilla's Video Background Play Fix extension to enable background audio playback
- Add foreground service with media notifications and lock screen controls
- Add next/prev controls and YouTube thumbnail artwork to notification
- Properly handle audio focus loss/gain (pause when camera takes focus, resume on return)
- Add visibility change detection to re-inject player if video becomes stale

## Test plan
- [x] Play a video with audio
- [x] Press home button to background the app - audio continues
- [x] Turn off screen - audio continues
- [x] Media notification shows with play/pause, prev/next, stop controls
- [x] Lock screen controls work
- [x] Opening camera pauses video, returning resumes it
- [x] Notification shows video title and thumbnail

Closes #28
Closes #77