### PR TITLE
Add Picture-in-Picture mode on swipe down

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode"
+            android:supportsPictureInPicture="true"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden|uiMode"
             android:label="@string/app_name"
             android:theme="@style/Theme.YouToob">
             <intent-filter>

--- a/app/src/main/assets/extensions/youtoob_player/scripts/src/11-gestures.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/src/11-gestures.js
@@ -174,16 +174,16 @@ function setupGestures(video, overlay) {
         toggleFullscreen();
     }
 
-    // Navigate back (for swipe down in portrait)
-    // Uses custom URL scheme to trigger native GeckoSession.goBack() instead of JS history.back()
-    // This avoids issues with YouTube's SPA intercepting history.back() calls
+    // Enter Picture-in-Picture mode (for swipe down in portrait)
+    // Uses custom URL scheme to trigger Android PiP mode via MainActivity
+    // Video continues playing in floating window; tapping returns to full app
     // Uses window flag to prevent multiple triggers across script instances
-    function navigateBack() {
-        if (window._youtoobNavigatingBack) return;
-        window._youtoobNavigatingBack = true;
+    function enterPipMode() {
+        if (window._youtoobEnteringPip) return;
+        window._youtoobEnteringPip = true;
         resetTransform(false);
-        location.href = 'youtoob://goback';
-        setTimeout(() => { window._youtoobNavigatingBack = false; }, NAVIGATE_BACK_DEBOUNCE_MS);
+        location.href = 'youtoob://pip';
+        setTimeout(() => { window._youtoobEnteringPip = false; }, NAVIGATE_BACK_DEBOUNCE_MS);
     }
 
     // Attach to document instead of overlay - overlay moves during fullscreen which corrupts touch handling
@@ -319,8 +319,8 @@ function setupGestures(video, overlay) {
                 // Portrait: swipe up → enter fullscreen
                 completeFullscreenGesture();
             } else if (dragDirection === 'down' && !isFullscreen() && deltaY > COMPLETE_THRESHOLD) {
-                // Portrait: swipe down → go back
-                navigateBack();
+                // Portrait: swipe down → enter PiP mode
+                enterPipMode();
             } else if (dragDirection === 'down' && isFullscreen() && deltaY > COMPLETE_THRESHOLD) {
                 // Fullscreen: swipe down → exit fullscreen
                 completeFullscreenGesture();

--- a/app/src/main/assets/extensions/youtoob_player/scripts/src/11-gestures.js
+++ b/app/src/main/assets/extensions/youtoob_player/scripts/src/11-gestures.js
@@ -174,16 +174,16 @@ function setupGestures(video, overlay) {
         toggleFullscreen();
     }
 
-    // Enter Picture-in-Picture mode (for swipe down in portrait)
-    // Uses custom URL scheme to trigger Android PiP mode via MainActivity
-    // Video continues playing in floating window; tapping returns to full app
+    // Enter miniplayer mode (for swipe down in portrait)
+    // Uses custom URL scheme to trigger miniplayer bar and navigate to YouTube home
+    // Audio continues playing; user can browse and tap bar to return to video
     // Uses window flag to prevent multiple triggers across script instances
-    function enterPipMode() {
-        if (window._youtoobEnteringPip) return;
-        window._youtoobEnteringPip = true;
+    function enterMiniplayerMode() {
+        if (window._youtoobEnteringMiniplayer) return;
+        window._youtoobEnteringMiniplayer = true;
         resetTransform(false);
-        location.href = 'youtoob://pip';
-        setTimeout(() => { window._youtoobEnteringPip = false; }, NAVIGATE_BACK_DEBOUNCE_MS);
+        location.href = 'youtoob://miniplayer';
+        setTimeout(() => { window._youtoobEnteringMiniplayer = false; }, NAVIGATE_BACK_DEBOUNCE_MS);
     }
 
     // Attach to document instead of overlay - overlay moves during fullscreen which corrupts touch handling
@@ -319,8 +319,8 @@ function setupGestures(video, overlay) {
                 // Portrait: swipe up → enter fullscreen
                 completeFullscreenGesture();
             } else if (dragDirection === 'down' && !isFullscreen() && deltaY > COMPLETE_THRESHOLD) {
-                // Portrait: swipe down → enter PiP mode
-                enterPipMode();
+                // Portrait: swipe down → enter miniplayer mode
+                enterMiniplayerMode();
             } else if (dragDirection === 'down' && isFullscreen() && deltaY > COMPLETE_THRESHOLD) {
                 // Fullscreen: swipe down → exit fullscreen
                 completeFullscreenGesture();

--- a/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
@@ -13,6 +13,7 @@ data class MediaInfo(val title: String?, val artist: String?)
 private const val YOUTOOB_SCHEME = "youtoob"
 private const val GOBACK_ACTION = "goback"
 private const val SETTINGS_ACTION = "settings"
+private const val PIP_ACTION = "pip"
 private const val ARTWORK_BITMAP_SIZE = 256
 
 class GeckoSessionDelegate(
@@ -27,7 +28,8 @@ class GeckoSessionDelegate(
     private val onUrlChange: (String, GeckoSession) -> Unit = { _, _ -> },
     private val onShareRequest: (ShareRequest, (Boolean) -> Unit) -> Unit = { _, callback -> callback(false) },
     private val onGoBackRequest: (GeckoSession) -> Unit = {},
-    private val onSettingsRequest: () -> Unit = {}
+    private val onSettingsRequest: () -> Unit = {},
+    private val onPipRequest: () -> Unit = {}
 ) : GeckoSession.ContentDelegate,
     GeckoSession.PermissionDelegate,
     GeckoSession.ProgressDelegate,
@@ -140,6 +142,7 @@ class GeckoSessionDelegate(
             when (action) {
                 GOBACK_ACTION -> onGoBackRequest(session)
                 SETTINGS_ACTION -> onSettingsRequest()
+                PIP_ACTION -> onPipRequest()
             }
             // Block the navigation - we handled it
             return GeckoResult.fromValue(AllowOrDeny.DENY)

--- a/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/gecko/GeckoSessionDelegate.kt
@@ -13,7 +13,7 @@ data class MediaInfo(val title: String?, val artist: String?)
 private const val YOUTOOB_SCHEME = "youtoob"
 private const val GOBACK_ACTION = "goback"
 private const val SETTINGS_ACTION = "settings"
-private const val PIP_ACTION = "pip"
+private const val MINIPLAYER_ACTION = "miniplayer"
 private const val ARTWORK_BITMAP_SIZE = 256
 
 class GeckoSessionDelegate(
@@ -29,7 +29,7 @@ class GeckoSessionDelegate(
     private val onShareRequest: (ShareRequest, (Boolean) -> Unit) -> Unit = { _, callback -> callback(false) },
     private val onGoBackRequest: (GeckoSession) -> Unit = {},
     private val onSettingsRequest: () -> Unit = {},
-    private val onPipRequest: () -> Unit = {}
+    private val onMiniplayerRequest: () -> Unit = {}
 ) : GeckoSession.ContentDelegate,
     GeckoSession.PermissionDelegate,
     GeckoSession.ProgressDelegate,
@@ -142,7 +142,7 @@ class GeckoSessionDelegate(
             when (action) {
                 GOBACK_ACTION -> onGoBackRequest(session)
                 SETTINGS_ACTION -> onSettingsRequest()
-                PIP_ACTION -> onPipRequest()
+                MINIPLAYER_ACTION -> onMiniplayerRequest()
             }
             // Block the navigation - we handled it
             return GeckoResult.fromValue(AllowOrDeny.DENY)

--- a/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/GeckoViewScreen.kt
@@ -171,7 +171,8 @@ fun GeckoViewScreen(
     navigateToUrl: String? = null,
     onFullscreenChange: (Boolean) -> Unit = {},
     onUrlChange: (String) -> Unit = {},
-    onSessionReady: (GeckoSession) -> Unit = {}
+    onSessionReady: (GeckoSession) -> Unit = {},
+    onPipRequest: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val activity = context as? Activity
@@ -331,7 +332,8 @@ fun GeckoViewScreen(
             },
             onSettingsRequest = {
                 context.startActivity(Intent(context, SettingsActivity::class.java))
-            }
+            },
+            onPipRequest = onPipRequest
         )
     }
 

--- a/app/src/main/java/com/wpinrui/youtoob/ui/components/MiniplayerBar.kt
+++ b/app/src/main/java/com/wpinrui/youtoob/ui/components/MiniplayerBar.kt
@@ -1,0 +1,115 @@
+package com.wpinrui.youtoob.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+data class MiniplayerState(
+    val isVisible: Boolean = false,
+    val isPlaying: Boolean = false,
+    val title: String? = null,
+    val artist: String? = null,
+    val videoUrl: String? = null
+)
+
+@Composable
+fun MiniplayerBar(
+    state: MiniplayerState,
+    onExpand: () -> Unit,
+    onPlayPause: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = state.isVisible,
+        enter = slideInVertically(initialOffsetY = { it }),
+        exit = slideOutVertically(targetOffsetY = { it }),
+        modifier = modifier
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .clickable { onExpand() }
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                // Title and artist
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = state.title ?: "Playing",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (state.artist != null) {
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = state.artist,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Play/Pause button
+                IconButton(
+                    onClick = onPlayPause,
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        imageVector = if (state.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (state.isPlaying) "Pause" else "Play",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                // Close button
+                IconButton(
+                    onClick = onClose,
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Close",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Swipe down on video in portrait mode shows a miniplayer bar and navigates to YouTube home
- User can browse YouTube while the miniplayer bar is visible
- Tap miniplayer bar → returns to the video
- Play/pause controls in miniplayer bar
- Close button to dismiss miniplayer

## Background
Original implementation used Android PiP, but YouTube blocks PiP playback for non-Premium users. This approach uses an in-app miniplayer bar instead, allowing users to browse YouTube while keeping a path back to their video.

See #79 for full discussion.

## Changes
- `MiniplayerBar.kt`: New Compose component for the miniplayer bar UI
- `MainActivity.kt`: Miniplayer state management, removed PiP code
- `GeckoSessionDelegate.kt`: Handle `youtoob://miniplayer` URL scheme
- `GeckoViewScreen.kt`: Report media state (playing, title, artist) to MainActivity
- `11-gestures.js`: Swipe-down triggers `youtoob://miniplayer` instead of PiP

## How it works
1. User swipes down on video page
2. JS triggers `youtoob://miniplayer` URL scheme
3. Kotlin saves current video URL, navigates GeckoView to YouTube home
4. MiniplayerBar appears above bottom nav
5. User can browse YouTube (search, settings, etc.)
6. Tap miniplayer bar → navigate back to saved video URL
7. If user taps another video, miniplayer disappears (new video replaces old)

## Test plan
- [ ] Swipe down on video → miniplayer bar appears, navigates to home
- [ ] Audio continues playing (if video-bg-play extension works)
- [ ] Tap miniplayer bar → returns to video
- [ ] Play/pause button works
- [ ] Close button stops playback and hides bar
- [ ] Tapping another video hides miniplayer
- [ ] Miniplayer hidden in fullscreen mode

## Related
- Closes #79
- Partial implementation of #29